### PR TITLE
Camera now starts in the scan fragment. Adjusting the Camera preview …

### DIFF
--- a/app/src/main/java/com/example/ingrediscan/MainActivity.kt
+++ b/app/src/main/java/com/example/ingrediscan/MainActivity.kt
@@ -102,9 +102,11 @@ class MainActivity : AppCompatActivity() {
         }
     }
     //helper function
-    private fun allPermissionsGranted() = REQUIRED_PERMISSIONS.all {
+    fun allPermissionsGranted() = REQUIRED_PERMISSIONS.all {
         ContextCompat.checkSelfPermission(this,it) == PackageManager.PERMISSION_GRANTED
     }
+
+
 
     /**
      * Called when a permission request has been completed.

--- a/app/src/main/java/com/example/ingrediscan/ui/scan/ScanFragment.kt
+++ b/app/src/main/java/com/example/ingrediscan/ui/scan/ScanFragment.kt
@@ -1,10 +1,14 @@
 package com.example.ingrediscan.ui.scan
 
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.camera.view.PreviewView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
@@ -14,8 +18,13 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.navigation.findNavController
 import com.example.ingrediscan.R
 
+import com.example.ingrediscan.Camera.CameraXFeatures
+import com.example.ingrediscan.MainActivity
 
 class ScanFragment : Fragment() {
+    //camera variables
+    private lateinit var previewView: PreviewView
+    private lateinit var cameraXFeatures : CameraXFeatures
 
     private lateinit var scanViewModel: ScanViewModel
     private var _binding: FragmentScanBinding? = null
@@ -26,8 +35,12 @@ class ScanFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+
         _binding = FragmentScanBinding.inflate(inflater, container, false)
         val root: View = binding.root
+        // init preview for binding
+        previewView = binding.previewView
+
         scanViewModel = ViewModelProvider(this)[ScanViewModel::class.java]
 
         binding.scanComposeView.apply {
@@ -41,12 +54,28 @@ class ScanFragment : Fragment() {
                 )
             }
         }
+
         return root
     }
 
     override fun onResume() {
         super.onResume()
         hideSystemBars()
+// is checking mainActivity is permissions where granted
+        val mainActivity = activity as? MainActivity
+        if(mainActivity?.allPermissionsGranted() == true){
+            cameraStart()
+        }
+        else{
+            Toast.makeText(requireContext(),"Camera permissions not granted",Toast.LENGTH_SHORT).show()
+        }
+
+
+    }
+    //call my camera class and starts the camera
+    private fun cameraStart(){
+        cameraXFeatures = CameraXFeatures(requireContext(), viewLifecycleOwner,previewView)
+        cameraXFeatures.startCamera()
     }
 
     override fun onPause() {

--- a/app/src/main/res/layout/fragment_scan.xml
+++ b/app/src/main/res/layout/fragment_scan.xml
@@ -4,6 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <!--Camera preview needs to be adjusted to the fragment so it can be seen -->
+    <androidx.camera.view.PreviewView
+        android:id="@+id/previewView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/scanComposeView"
         android:layout_width="0dp"
@@ -12,5 +19,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
…to work with the fragment is needed


# Description
I implemented the camera to the scan fragment. Jai will work with the Preview and adjust it to the page so it looks nice. I moved the preview to the back so it would block the page. 

Fixes # (issue & link)
#36 
## Authors
@William-AR @JaisonNoah808 

## Type of change
Camera starts in the scan fragment is moved the preview to the back. Needs to be adjust to work with the scan page.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## UML Diagram
Please provide a UML diagram that shows the interaction of your additions amoung the the surrounding framework. 
![mermaid-diagram-2025-04-13-081457](https://github.com/user-attachments/assets/cd1cfdc9-6af6-4980-9ee3-c66775c1e108)

# How Has This Been Tested?

- [x] Test A : used android emulator to test with the Pixel 9 xl.
- [x] Test B : used android emulator to test with a lower version phone. 
- [ ] Is there unit test coverage?

**Test Configuration (if relevant)**:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Review Requested
use @ mentions to ask for specific members to review this code
@JaisonNoah808 @AlanReisenau @onasito 