### PR TITLE
Added ability to create accounts using the signup button

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ if (localPropertiesFile.exists()) {
 
 plugins {
     id("com.android.application")
-    id("com.google.gms.google-services")
-    id("com.google.firebase.firebase-perf")
+    id("com.google.gms.google-services")   //For Firebase
+    id("com.google.firebase.firebase-perf")  //For Firebase
 //    alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
@@ -117,9 +117,11 @@ dependencies {
     // Truth library for better assertions
     testImplementation("com.google.truth:truth:1.1.3")
 
-    implementation(platform("com.google.firebase:firebase-bom:33.10.0"))
+    //For Firebase
+    implementation(platform("com.google.firebase:firebase-bom:33.12.0"))
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-perf")
+    implementation("com.google.firebase:firebase-auth") // For user signup
 
     // Compose dependencies to trasnfer jetpack compose to XML
     implementation("androidx.compose.ui:ui:1.7.8")

--- a/app/src/main/java/com/example/ingrediscan/ui/createAccount/CreateAccountFragment.kt
+++ b/app/src/main/java/com/example/ingrediscan/ui/createAccount/CreateAccountFragment.kt
@@ -1,23 +1,27 @@
 package com.example.ingrediscan.ui.createAccount
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.example.ingrediscan.R
 import com.example.ingrediscan.databinding.FragmentCreateAccountBinding
+import com.example.ingrediscan.model.Password
+import com.example.ingrediscan.model.Email
+import androidx.lifecycle.Observer
+import com.google.firebase.auth.FirebaseUser
 
 class CreateAccountFragment : Fragment() {
-
     private var _binding: FragmentCreateAccountBinding? = null
-
     // This property is only valid between onCreateView and onDestroyView.
     private val binding get() = _binding!!
+    private lateinit var createAccountViewModel: CreateAccountViewModel
+    private val TAG = "CreateAccountFragment"
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -32,19 +36,78 @@ class CreateAccountFragment : Fragment() {
 
         // sign up button
         binding.buttonSignup.setOnClickListener {
+            // TODO: Use "fullname" somewhere in the project"
             val fullname = binding.enterFullname.text.toString().trim()
-            val username = binding.enterUsername.text.toString().trim()
+            val email = binding.enterUsername.text.toString().trim() //email (to be more accurate)
             val password = binding.enterPassword.text.toString().trim()
             val confirmPassword = binding.confirmPassword.text.toString().trim()
 
-            // TO DO: checking error and valid input
+            // Pop-up error message if fields are empty
+            if (email.isEmpty() || password.isEmpty() || confirmPassword.isEmpty() || fullname.isEmpty()) {
+                Toast.makeText(requireContext(), "Please fill in all fields.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener // Exit the listener if fields are empty
+            }
+            // Pop-up error message if passwords don't match
+            if (password != confirmPassword) {
+                Toast.makeText(requireContext(), "Passwords do not match.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener // Exit if passwords don't match
+            }
 
-            // successful sign up
-            findNavController().navigate(R.id.signup_to_home)
+            // Email validation using Email.kt
+            try {
+                Email(email)
+            } catch (e: IllegalArgumentException) {
+                Toast.makeText(requireContext(), e.message, Toast.LENGTH_LONG).show()
+                return@setOnClickListener
+            }
+
+            // Password validation using Password.kt
+            try {
+                Password.validate(password)
+                // successful sign up if we get to here
+                //findNavController().navigate(R.id.signup_to_home) // Navigate to home screen on success
+                createAccountViewModel.createAccount(email, password)
+            } catch (e: IllegalArgumentException) {
+                // Password validation failed
+                Toast.makeText(requireContext(), e.message, Toast.LENGTH_LONG).show()
+            }
 
         }
+        // LiveData observation
+        // .observe() allows us to "watch" the currentUser Livedata for any changes to its value,
+        // When the value of currentUser changes, the code inside the observe() method will run.
+        // Observe currentUser changes
+        createAccountViewModel.currentUser.observe(viewLifecycleOwner, Observer { user ->
+            updateUI(user)
+        })
+
+        // Observe error messages
+        // viewLifeCycleOwner tells LiveData to only observe the currentUser data as long as the view is active.
+        // Helps prevent memory leaks
+        createAccountViewModel.errorMessage.observe(viewLifecycleOwner, Observer { message ->
+            if (!message.isNullOrEmpty()) {
+                Log.e(TAG, "Sign-up error: $message")
+                Toast.makeText(context, "Sign-up failed: $message", Toast.LENGTH_LONG).show()
+            }
+        })
 
         return root
+    }
+
+    /**
+     * Update the UI based on the current user's authentication state.
+     * If the user is signed in, navigate to the home screen. Otherwise, display an error message.
+     *
+     * @param user The current user, or null if no user is signed in.
+     */
+    private fun updateUI(user: FirebaseUser?) {
+        if (user != null){
+            Log.d(TAG, "User signed in: ${user.email}")
+            Toast.makeText(context, "Sign-up successful! User: ${user.email}", Toast.LENGTH_SHORT).show()
+            findNavController().navigate(R.id.signup_to_home)
+        } else {
+            Log.d(TAG, "No user signed up (or sign-up failed, check error message)")
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/ingrediscan/ui/createAccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/com/example/ingrediscan/ui/createAccount/CreateAccountViewModel.kt
@@ -1,18 +1,57 @@
 package com.example.ingrediscan.ui.createAccount
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
 
 class CreateAccountViewModel : ViewModel() {
+    // TODO: Use "username" somewhere in the project
     private val _username = MutableLiveData<String>()
     val username: LiveData<String> get() = _username
 
     private val _password = MutableLiveData<String>()
     val password: LiveData<String> get() = _password
 
-    fun createAccount(username: String, password: String) {
-        _username.value = username
+    private val _currentUser = MutableLiveData<FirebaseUser?>()
+    val currentUser: LiveData<FirebaseUser?> get() = _currentUser
+
+    private val _errorMessage = MutableLiveData<String?>()
+    val errorMessage: LiveData<String?> get() = _errorMessage
+
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+
+    companion object {
+        private const val TAG = "CreateAccountViewModel"
+    }
+
+    /**
+     * Create a new user account with the provided email and password.
+     * This method uses Firebase's createUserWithEmailAndPassword method to create a new user account.
+     *
+     * @Source https://firebase.google.com/docs/auth/android/password-auth
+     * @param email The user's email address.
+     * @param password The user's password.
+     * @return A LiveData object representing the result of the sign-up operation.
+     */
+    fun createAccount(email: String, password: String) {
+        _username.value = email
         _password.value = password
+
+        auth.createUserWithEmailAndPassword(email, password)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    Log.d(TAG, "createUserWithEmail:success")
+                    val user = auth.currentUser
+                    _currentUser.value = user
+                    _errorMessage.value = null
+                } else {
+                    Log.w(TAG, "createUserWithEmail:failure", task.exception)
+                    _errorMessage.value = task.exception?.message ?: "Sign-up failed"
+                    _currentUser.value = null
+                }
+            }
     }
 }

--- a/app/src/main/res/layout/fragment_create_account.xml
+++ b/app/src/main/res/layout/fragment_create_account.xml
@@ -47,7 +47,7 @@
             android:layout_marginBottom="15dp"
             android:background="@drawable/rounded_corner_background"
             android:ems="10"
-            android:hint="@string/username"
+            android:hint="@string/Email"
             android:inputType="text"
             android:paddingLeft="15dp"
             android:paddingBottom="30dp" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,5 @@
     <string name="create_account">Create Account</string>
     <string name="fullname">Full Name</string>
     <string name="confirmpw">Confirm Password</string>
+    <string name="Email">Email</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.google.gms.google-services") version "4.4.2" apply false
-    id("com.google.firebase.firebase-perf") version "1.4.2" apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false // Uncomment this to use Firebase
+    id("com.google.firebase.firebase-perf") version "1.4.2" apply false // Uncomment this to use Firebase
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false


### PR DESCRIPTION
# Description

Added functionality to the signup page (CreateAccount UI pages) in the app. Users can now create account using this page. The new code uses that Email.kt and Password.kt files to ensure requirements are met. If a requirement is not met, a little notification pops up telling the user what's wrong. New accounts can be seen in the apps Firebase page under authentication. 

## Fixes  (issue & link)
Fixes issue #85 

## Authors
use @ mentions to add the other contributors to this change
@J-Doza 
## Type of change

- [X] New feature (non-breaking change which adds functionality)

## UML Diagram
![PR85](https://github.com/user-attachments/assets/254d7507-39b8-4263-a9ec-e85843dabef6)


# How Has This Been Tested?

- [X] Is there unit test coverage?

The Email.kt and Password.kt files already have unit tests but i was not able to figure out how to unit test UI elements. No crashes occured when I was testing the UI pages myself. If a user fails a signup attempt, the app does NOT crash and simply shows a descriptive error message allowing the user to try again. If a user tries to create an account that already exists, an error message is given and a user can try again. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Review Requested
use @ mentions to ask for specific members to review this code
@onasito @mx-xsq @AlanReisenau @William-AR 